### PR TITLE
finalize context before format response

### DIFF
--- a/modules/@themost/express/package-lock.json
+++ b/modules/@themost/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/express",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/modules/@themost/express/package.json
+++ b/modules/@themost/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/express",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "MOST Data ORM Express Middleware",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/modules/@themost/express/src/app.js
+++ b/modules/@themost/express/src/app.js
@@ -251,8 +251,8 @@ class ExpressDataApplication extends IApplication {
               return context;
             }
           });
-          req.on('end', () => {
-            //on end
+          res.on('close', () => {
+            //on clse
             if (req.context) {
               //finalize data context
               return req.context.finalize( () => {

--- a/modules/@themost/express/src/middleware.js
+++ b/modules/@themost/express/src/middleware.js
@@ -150,12 +150,9 @@ function tryFormat(data, req, res) {
  * @param {NextFunction} next
  */
 function tryFormatStream(data, req, res, next) {
-    if (req.context) {
-        return req.context.finalize(() => {
-            return new StreamFormatter(data).execute(req, res, next);
-        });
-    }
-    return new StreamFormatter(data).execute(req, res, next);
+    return finalizeContext(req, () => {
+        return new StreamFormatter(data).execute(req, res, next);
+    });
 }
 
 /**


### PR DESCRIPTION
This PR finalized context before formatting response. This operation should be implemented for some cases where the request was closed but it seems that the context is still alive.